### PR TITLE
Allow tracking queries from other database connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ class YourTest extends TestCase
 }
 ```
 
+If you want to track queries from another database, you can specify the connection name during initialization:
+
+```php
+AssertQueryCount::trackQueries('sqlite');
+```
+
 ## Available assertions/methods
 
 You can use the following methods, their names should be self-explanatory:
@@ -52,12 +58,17 @@ $this->assertQueryCountLessThan(6);     // Should be less than 6 queries
 $this->assertQueryCountGreaterThan(4);  // Should be more than 4 queries
 ```
 
-All these methods can accept a closure as an extra argument. The assertion will only take in account the queries performed inside the closure. If you use this way of testing, you don't need to call `trackQueries` yourself.
+All these methods can accept a closure as an extra argument. The assertion will only take in account the queries performed inside the closure. If you use this way of testing, you don't need to call `trackQueries` yourself. You can also specify
+the name of the database connection after the closure.
 
 ```php
 $this->assertQueryCountMatches(2, function() {
     // assertion will pass if exactly 2 queries happen here.
 });
+
+$this->assertQueryCountLessThan(3, function() {
+    // assertion will pass if less than 3 queries happen in the sqlite database.
+}, 'sqlite');
 ```
 
 ## Testing

--- a/tests/AssertsQueryCountsTest.php
+++ b/tests/AssertsQueryCountsTest.php
@@ -12,26 +12,48 @@ class QueryCounterTest extends TestCase
     public function setUp(): void
     {
         parent::setUp();
-
-        AssertsQueryCounts::trackQueries();
     }
 
     /** @test */
     public function no_queries_are_logged_when_none_are_executed()
     {
+        AssertsQueryCounts::trackQueries();
         $this->assertNoQueriesExecuted();
+
+        AssertsQueryCounts::trackQueries('other');
+        $this->assertNoQueriesExecuted(null, 'other');
+    }
+
+    /** @test */
+    public function no_queries_are_logged_when_none_are_executed_in_callable()
+    {
+        $this->assertNoQueriesExecuted(function () {
+        });
+
+        $this->assertNoQueriesExecuted(function () {
+        }, 'other');
     }
 
     /** @test */
     public function queries_are_counted_when_executed()
     {
+        AssertsQueryCounts::trackQueries();
         DB::select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
-
         $this->assertQueryCountMatches(1);
+        $this->assertQueryCountMatches(0, null, 'other');
 
         DB::select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
-
         $this->assertQueryCountMatches(2);
+        $this->assertQueryCountMatches(0, null, 'other');
+
+        AssertsQueryCounts::trackQueries('other');
+        DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+        $this->assertQueryCountMatches(2);
+        $this->assertQueryCountMatches(1, null, 'other');
+
+        DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+        $this->assertQueryCountMatches(2);
+        $this->assertQueryCountMatches(2, null, 'other');
     }
 
     /** @test */
@@ -45,19 +67,34 @@ class QueryCounterTest extends TestCase
             DB::select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
             DB::select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
         });
+
+        $this->assertQueryCountMatches(1, function () {
+            DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+        }, 'other');
+
+        $this->assertQueryCountMatches(2, function () {
+            DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+            DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+        }, 'other');
     }
 
     /** @test */
     public function we_can_check_for_less_than_queries()
     {
+        AssertsQueryCounts::trackQueries();
         collect(range(1, 5))->each(function () {
             DB::select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
         });
-
         $this->assertQueryCountMatches(5);
-
         $this->assertQueryCountLessThan(6);
-
         $this->assertQueryCountGreaterThan(4);
+
+        AssertsQueryCounts::trackQueries('other');
+        collect(range(1, 5))->each(function () {
+            DB::connection('other')->select('SELECT * FROM sqlite_master WHERE type = "table"'); // SQLite query
+        });
+        $this->assertQueryCountMatches(5, null, 'other');
+        $this->assertQueryCountLessThan(6, null, 'other');
+        $this->assertQueryCountGreaterThan(4, null, 'other');
     }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -14,5 +14,10 @@ class TestCase extends Orchestra
             'database' => ':memory:',
             'prefix' => '',
         ]);
+        $app['config']->set('database.connections.other', [
+            'driver' => 'sqlite',
+            'database' => ':memory:',
+            'prefix' => '',
+        ]);
     }
 }


### PR DESCRIPTION
This PR allows to track queries from a different database, by passing the connection name to `AssertQueryCount::trackQueries()` or after the closure in the available assertions.