### PR TITLE
Explicitly mark parameter `$closure` as nullable

### DIFF
--- a/src/AssertsQueryCounts.php
+++ b/src/AssertsQueryCounts.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\DB;
 
 trait AssertsQueryCounts
 {
-    public function assertNoQueriesExecuted(Closure $closure = null): void
+    public function assertNoQueriesExecuted(?Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -22,7 +22,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountMatches(int $count, Closure $closure = null): void
+    public function assertQueryCountMatches(int $count, ?Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -37,7 +37,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountLessThan(int $count, Closure $closure = null): void
+    public function assertQueryCountLessThan(int $count, ?Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();
@@ -52,7 +52,7 @@ trait AssertsQueryCounts
         }
     }
 
-    public function assertQueryCountGreaterThan(int $count, Closure $closure = null): void
+    public function assertQueryCountGreaterThan(int $count, ?Closure $closure = null): void
     {
         if ($closure) {
             self::trackQueries();


### PR DESCRIPTION
Implicitly marking parameter $closure as nullable is deprecated, the explicit nullable type must be used instead in PHP 8.4.